### PR TITLE
Update Readme.md - Reference to "Open-Source-Orchard-Core-Extensions"

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,7 +20,7 @@ Before you dive deep into this module it'd be best if you make sure that you hav
 
 The [Open-Source Orchard Core Extensions](https://github.com/Lombiq/Open-Source-Orchard-Core-Extensions) repository showcases a web app using Orchard Core from NuGet packages, and it includes this module too. Furthermore, it also contains all of Lombiq's open-source Orchard themes and modules as a bonus! (Check them out for what we have already solved for you.) So, just use that to work with this module:
 
-1. Complete [the repository's prerequisites](https://github.com/Lombiq/Open-Source-Orchard-Core-Extensions#prerequisites-and-getting-started) and clone it to the latest `dev` branch.
+1. Complete [the repository's prerequisites](https://github.com/Lombiq/Open-Source-Orchard-Core-Extensions#prerequisites-and-getting-started) and clone the latest `dev` "[Open-Source-Orchard-Core-Extensions](https://github.com/Lombiq/Open-Source-Orchard-Core-Extensions)" branch.
 2. Make sure the `Lombiq.OSOCE.Web` project is the startup project (it should be).
 3. Start the app with <kbd>Ctrl</kbd> + <kbd>F5</kbd>.
 4. Set up the website using the "Training Demo" recipe.


### PR DESCRIPTION
The reference to "it", to intend the "Open-Source-Orchard-Core-Extensions" was confusing me, because I supposed was the "Orchard-Training-Demo-Module" dev branch, where I was reading this Readme file, and not the "Open-Source-Orchard-Core-Extensions".