### PR TITLE
OSOE-1229: Fixing analyzer violation

### DIFF
--- a/Lombiq.TrainingDemo/Map.cs
+++ b/Lombiq.TrainingDemo/Map.cs
@@ -28,7 +28,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Lombiq.TrainingDemo;
 
-internal static class Map
+public static class Map
 {
 #pragma warning disable S3241 // Methods should not return values that are never used
     private static T Pointer<T>() => default;


### PR DESCRIPTION
[OSOE-1229](https://lombiq.atlassian.net/browse/OSOE-1229)

[OSOE-1229]: https://lombiq.atlassian.net/browse/OSOE-1229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ