### PR TITLE
Update dependencies: Microsoft.NET.Test.Sdk 18.9.0

### DIFF
--- a/Lombiq.TrainingDemo.Tests/Lombiq.TrainingDemo.Tests.csproj
+++ b/Lombiq.TrainingDemo.Tests/Lombiq.TrainingDemo.Tests.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Moq.AutoMock" Version="4.0.3" />
     <PackageReference Include="Shouldly" Version="4.3.0" />

--- a/Lombiq.TrainingDemo.Tests/Lombiq.TrainingDemo.Tests.csproj
+++ b/Lombiq.TrainingDemo.Tests/Lombiq.TrainingDemo.Tests.csproj
@@ -20,8 +20,8 @@
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Moq.AutoMock" Version="4.0.3" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Lombiq.TrainingDemo.Tests/Lombiq.TrainingDemo.Tests.csproj
+++ b/Lombiq.TrainingDemo.Tests/Lombiq.TrainingDemo.Tests.csproj
@@ -20,8 +20,8 @@
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Moq.AutoMock" Version="4.0.3" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="xunit.v3" Version="4.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Part of OSOE-1312.

Merges:
- #215 `renovate/non-breaking-dependency-versions` — Microsoft.NET.Test.Sdk → 18.9.0.

Note: the xUnit v4 update (#216) was left out of this batch — it requires migrating `dotnet test` to the new Microsoft.Testing.Platform runner mode, which needs a dedicated, coordinated change (see https://aka.ms/dotnet-test-mtp-error). Renovate has since auto-closed #216 following [Lombiq/renovate-config#12](https://github.com/Lombiq/renovate-config/pull/12), which disables automated xUnit major updates.
