### PR TITLE
OSOE-1308: Migrate Training Demo tests to Microsoft Testing Platform

### DIFF
--- a/Lombiq.TrainingDemo.Tests/Lombiq.TrainingDemo.Tests.csproj
+++ b/Lombiq.TrainingDemo.Tests/Lombiq.TrainingDemo.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,15 +17,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.GitHubActionsReport" Version="2.4.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" Version="2.4.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="2.4.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Moq.AutoMock" Version="4.0.3" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Lombiq.TrainingDemo.Tests/Readme.md
+++ b/Lombiq.TrainingDemo.Tests/Readme.md
@@ -8,6 +8,6 @@ You may have noticed that the structure of the unit test project is conveniently
 
 We use the [xUnit framework](https://xunit.net/) for testing, because it's great and Orchard's tests use it too. You could of course use any other unit testing framework if you'd like to but you're on your own :-).
 
-Run these tests from Test Explorer in an IDE with Microsoft Testing Platform support, or use `dotnet test --project Lombiq.TrainingDemo.Tests.csproj` with .NET SDK 10 or later. You can also run the built executable directly. The project references `xunit.v3` 4.0.0 and enables the Microsoft Testing Platform runner. The repository's _global.json_ selects this runner for `dotnet test`; see the [xUnit documentation](https://xunit.net/docs/getting-started/v3/microsoft-testing-platform) for details.
+Run these tests from Test Explorer in an IDE with Microsoft Testing Platform support, or use `dotnet test --project Lombiq.TrainingDemo.Tests.csproj` with .NET SDK 10 or later. You can also run the built executable directly. The project references `xunit.v3` and enables the Microsoft Testing Platform runner. The repository's _global.json_ selects this runner for `dotnet test`; see the [xUnit documentation](https://xunit.net/docs/getting-started/v3/microsoft-testing-platform) for details.
 
 To start, head over to _Services/TestedServiceTests_!

--- a/Lombiq.TrainingDemo.Tests/Readme.md
+++ b/Lombiq.TrainingDemo.Tests/Readme.md
@@ -8,6 +8,6 @@ You may have noticed that the structure of the unit test project is conveniently
 
 We use the [xUnit framework](https://xunit.net/) for testing, because it's great and Orchard's tests use it too. You could of course use any other unit testing framework if you'd like to but you're on your own :-).
 
-It's worth noting how such tests can be executed: If you're using Visual Studio then the tests will simply show up in the Test Explorer window and you can right click on them and select Run. Otherwise, you can just run the executable built from this project, or you can use a test runner; check out the [xUnit docs](https://xunit.net/) for details. Note that for this to work the project should reference the `xunit.runner.visualstudio` and `xunit` packages (but you need that anyway to write xUnit tests :-)).
+Run these tests from Test Explorer in an IDE with Microsoft Testing Platform support, or use `dotnet test --project Lombiq.TrainingDemo.Tests.csproj` with .NET SDK 10 or later. You can also run the built executable directly. The project references `xunit.v3` 4.0.0 and enables the Microsoft Testing Platform runner. The repository's _global.json_ selects this runner for `dotnet test`; see the [xUnit documentation](https://xunit.net/docs/getting-started/v3/microsoft-testing-platform) for details.
 
 To start, head over to _Services/TestedServiceTests_!

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}


### PR DESCRIPTION
[OSOE-1308](https://lombiq.atlassian.net/browse/OSOE-1308)
Move the Training Demo unit tests to xUnit 4 and Microsoft Testing Platform, replacing the VSTest packages with native reporting and hang dump extensions. Add the runner selection in global.json and update the test execution instructions.

Part of https://github.com/Lombiq/Testing-Toolbox/issues/92. Coordinated integration: https://github.com/Lombiq/Open-Source-Orchard-Core-Extensions/pull/1335.

Validation: all 4 Training Demo unit tests pass on MTP with a generated TRX report; the full restored OSOCE solution builds with zero warnings/errors.


[OSOE-1308]: https://lombiq.atlassian.net/browse/OSOE-1308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ